### PR TITLE
fix test.java path error

### DIFF
--- a/lab1.md
+++ b/lab1.md
@@ -680,7 +680,8 @@ repeatedly calls `hasNext` and `next` on the `SeqScan` operator. As tuples are o
 printed out on the command line.
 
 We **strongly recommend** you try this out as a fun end-to-end test that will help you get experience writing your own
-test programs for simpledb. You should create the file "test.java" in the src/simpledb directory with the code above,
+test programs for simpledb. You should create the file "test.java" in the src/java/simpledb directory with the code above, 
+and you should add some "import" statement above the code, 
 and place the `some_data_file.dat` file in the top level directory. Then run:
 
 ```


### PR DESCRIPTION
Background:

```bash
beeyan@beeyan-virtual-machine:~/desktop/simple-db-hw-2021$ cd ..
beeyan@beeyan-virtual-machine:~/desktop$ java -classpath dist/simpledb.jar simpledb.test
Error: the main class could not be found or loaded simpledb.test
reason: java.lang.ClassNotFoundException :  simpledb.test
```

and I found the problem is that the test.java path should be src/java/simpledb/
not src/simpledb/

This really confused me!
