### PR TITLE
Fixbug of BufferPoolWriteTest: Should use `bufferPool.getPage()` to replace `new HeapPage()`, otherwise the HeapPage is dangling

### DIFF
--- a/test/simpledb/BufferPoolWriteTest.java
+++ b/test/simpledb/BufferPoolWriteTest.java
@@ -46,8 +46,7 @@ public class BufferPoolWriteTest extends TestUtil.CreateHeapFile {
                 byte[] emptyData = HeapPage.createEmptyPageData();
                 bw.write(emptyData);
                 bw.close();
-    			HeapPage p = new HeapPage(new HeapPageId(super.getId(), super.numPages() - 1),
-    					HeapPage.createEmptyPageData());
+    			HeapPage p = (HeapPage) Database.getBufferPool().getPage(tid, new HeapPageId(super.getId(), super.numPages() - 1), null);
     	        p.insertTuple(t);
     			dirtypages.add(p);
     		}


### PR DESCRIPTION
Hi, thank you for this wonderful series of assignments! I find a bug which causes the `handleManyDirtyPages` test to fail.

In the line I changed, I propose to use `BufferPool.getPage()` to replace `new HeapPage()`. Otherwise, that HeapPage is dangling, and is contrary to the architecture and the spirit of the question pdf.

More details: With the old code, the BufferPool even does not know the existence of that page, let alone managing it. Thus, the test `handleManyDirtyPages` can fail, because nobody knows that dirty page - it is dangling.