### PR TITLE
Update BufferPoolWriteTest.java

### DIFF
--- a/test/simpledb/BufferPoolWriteTest.java
+++ b/test/simpledb/BufferPoolWriteTest.java
@@ -109,16 +109,16 @@ public class BufferPoolWriteTest extends TestUtil.CreateHeapFile {
     	// delete 504 tuples from the first page
     	for (int i = 0; i < 504; ++i) {
     		Tuple t = tuples.get(i);
+            HeapPage p = (HeapPage) Database.getBufferPool().getPage(tid, t.getRecordId().getPageId(), Permissions.READ_ONLY);
         	Database.getBufferPool().deleteTuple(tid, t);
-        	HeapPage p = (HeapPage) Database.getBufferPool().getPage(tid, t.getRecordId().getPageId(), Permissions.READ_ONLY);
         	assertEquals(i+1, p.getNumEmptySlots());
         }
     	
     	// delete 504 tuples from the second page
     	for (int i = 0; i < 504; ++i) {
     		Tuple t = tuples.get(i+504);
+            HeapPage p = (HeapPage) Database.getBufferPool().getPage(tid, t.getRecordId().getPageId(), Permissions.READ_ONLY);
         	Database.getBufferPool().deleteTuple(tid, t);
-        	HeapPage p = (HeapPage) Database.getBufferPool().getPage(tid, t.getRecordId().getPageId(), Permissions.READ_ONLY);
         	assertEquals(i+1, p.getNumEmptySlots());
         }
     }


### PR DESCRIPTION
In the JavaDocs above DbFile#deleteTuple, it states:
`t: The tuple to delete.  This tuple should be updated to reflect that it is no longer stored on any page.`, which means after deletion, the `rid` of `t` is not supposed to contain any information.
Hence, calling `t.getRecordId()` after deleting `t` is supposed to throw a `NullPointerException`, which is undesirable for this test.