### PR TITLE
fix delete & rename failed in logTruncate on Windows

### DIFF
--- a/src/java/simpledb/common/Database.java
+++ b/src/java/simpledb/common/Database.java
@@ -72,6 +72,9 @@ public class Database {
 
     // reset the database, used for unit tests only.
     public static void reset() {
+        if (_instance != null) {
+            _instance.get()._logfile.close();
+        }
         _instance.set(new Database());
     }
 

--- a/src/java/simpledb/storage/LogFile.java
+++ b/src/java/simpledb/storage/LogFile.java
@@ -437,6 +437,7 @@ public class LogFile {
 
         raf.close();
         logFile.delete();
+        logNew.close();
         newFile.renameTo(logFile);
         raf = new RandomAccessFile(logFile, "rw");
         raf.seek(raf.length());
@@ -571,4 +572,11 @@ public class LogFile {
         raf.getChannel().force(true);
     }
 
+    public void close() {
+        try {
+            raf.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
 }


### PR DESCRIPTION
On windows platform, _logTruncate_ function unable to delete log and rename logxxxxx to log

_logFile.delete();_ 
_newFile.renameTo(logFile);_

The 2 lines will return false, because each _LogFile_ object will NOT close _raf_ when _Database.reset()_ be called in _setup()_ in LogTest.java, and _logNew_ also need to be closed.



